### PR TITLE
Build upstream image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,7 +13,7 @@ jobs:
 
     # Overwrite this pipeline with the template in common-pipelines.
     - set_pipeline: self
-      file: common-pipelines/container/pipeline.yml
+      file: common-pipelines/container/pipeline-external-repository.yml
       var_files:
         - pipeline-config/ci/vars.yml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -23,7 +23,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/common-pipelines
-    branch: pipeline-config-repo
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 # The repository containing pipeline configuration. Set 'pipeline-config-repo' in Credhub.
@@ -31,5 +31,5 @@ resources:
   type: git
   source:
     uri: https://github.com/((pipeline-config-repo))
-    branch: build-upstream
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,3 +1,3 @@
-oci-build-params:
-  # todo replace with private base image
-  BUILD_ARG_base_image: "ubuntu:22.04"
+base-image: ubuntu
+base-image-tag: "22.04"
+oci-build-params: {}

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,2 +1,3 @@
-# All empty by default. See ../README.md#Usage for details.
-oci-build-params: {}
+oci-build-params:
+  # todo replace with private base image
+  BUILD_ARG_base_image: "ubuntu:22.04"

--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,3 +1,6 @@
 base-image: ubuntu
 base-image-tag: "22.04"
+image-repository: git-resource
 oci-build-params: {}
+src-repo: concourse/git-resource
+src-target-branch: master


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add configuration to the repo to start building an image from the upstream `concourse/git-resource` repository.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Security considerations already noted in https://github.com/cloud-gov/common-pipelines/pull/14
